### PR TITLE
Add dedicated achievements pages

### DIFF
--- a/src/pages/contributors.astro
+++ b/src/pages/contributors.astro
@@ -1,4 +1,5 @@
 ---
+import CTA from "../components/CTA.astro";
 import Layout from "../layouts/Layout.astro";
 import { contributors } from '../util/getContributors'
 
@@ -40,6 +41,10 @@ const dataID = 'contributor-usernames';
   <footer class="mx-auto max-w-prose">
     <p>One of {contributors.length} contributors! 🧑‍🚀💜</p>
     <small>Data is updated once per day at midnight GMT.</small>
+
+    <div class="my-24">
+      <CTA href="/v1/achievements/">Browse achievements →</CTA>
+    </div>
   </footer>
 
   <datalist id={dataID}>

--- a/src/pages/v1/achievements/[groupID]/[class].astro
+++ b/src/pages/v1/achievements/[groupID]/[class].astro
@@ -6,6 +6,7 @@ import {
   achievementClassGradientFrom,
   achievementClassSlug,
 } from '../../../../util/achievementClasses';
+import { resizedGitHubAvatarURL } from '../../../../util/resizedGitHubAvatarURL';
 
 export function getStaticPaths() {
   return globalAchievements.map((achievement) => ({
@@ -87,7 +88,7 @@ const { title, details, contributors, class: cls, repo } = Astro.props;
               <img
                 width="28"
                 height="28"
-                src={contributor.avatar_url}
+                src={resizedGitHubAvatarURL(contributor.avatar_url, 42)}
                 alt=""
                 class="w-7 h-7 rounded-full object-cover bg-neutral-700"
                 loading="lazy"

--- a/src/pages/v1/achievements/[groupID]/[class].astro
+++ b/src/pages/v1/achievements/[groupID]/[class].astro
@@ -76,11 +76,13 @@ const { title, details, contributors, class: cls, repo } = Astro.props;
     </header>
 
     <section class="space-y-4">
-      <h2 class="flex gap-2 items-center">
+      <h2>
         <span class="font-bold text-2xl">
           Contributors with this achievement
         </span>
-        <span class="px-3 py-1 bg-neutral-800 rounded-full">
+        <span
+          class="inline-block align-baseline ml-2 px-3 py-1 bg-neutral-800 rounded-full"
+        >
           {contributors.length}
         </span>
       </h2>

--- a/src/pages/v1/achievements/[groupID]/[class].astro
+++ b/src/pages/v1/achievements/[groupID]/[class].astro
@@ -1,0 +1,112 @@
+---
+import CTA from '../../../../components/CTA.astro';
+import Layout from '../../../../layouts/Layout.astro';
+import { globalAchievements } from '../../../../util/getGlobalStats';
+import {
+  achievementClassGradientFrom,
+  achievementClassSlug,
+} from '../../../../util/achievementClasses';
+
+export function getStaticPaths() {
+  return globalAchievements.map((achievement) => ({
+    params: {
+      groupID: achievement.groupID,
+      class: achievementClassSlug(achievement.class),
+    },
+    props: achievement,
+  }));
+}
+
+type Props = typeof globalAchievements[number];
+
+const { title, details, contributors, class: cls, repo } = Astro.props;
+---
+
+<Layout title={`${title} — Astro Achievements`} description={details}>
+  <div class="space-y-16">
+    <header class="space-y-2">
+      <h1 class="text-4xl font-extrabold">
+        <span
+          class:list={[
+            'bg-gradient-to-br to-white inline-block w-[.75em] h-[.75em] mr-0.5 rounded-full translate-y-px',
+            achievementClassGradientFrom(cls),
+          ]}></span>
+        <span
+          class:list={[
+            'bg-gradient-to-br to-white bg-clip-text text-transparent',
+            achievementClassGradientFrom(cls),
+          ]}
+        >
+          {title}
+        </span>
+      </h1>
+
+      <div class="flex flex-wrap gap-x-8 gap-y-3 items-end justify-between">
+        <p class="text-2xl font-light">{details}</p>
+        {
+          repo && (
+            <p class="text-sm">
+              <a
+                href={`https://github.com/withastro/${repo}/`}
+                class="inline-flex gap-2 items-center group text-accent-300 hover:underline"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 16 16"
+                  width="1.25rem"
+                  height="1.25rem"
+                  class="fill-neutral-50 opacity-20 group-hover:opacity-40"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M8 0a8 8 0 0 0-2.5 15.6c.4 0 .5-.2.5-.4v-1.5c-2 .4-2.5-.5-2.7-1 0-.1-.5-.9-.8-1-.3-.2-.7-.6 0-.6.6 0 1 .6 1.2.8.7 1.2 1.9 1 2.4.7 0-.5.2-.9.5-1-1.8-.3-3.7-1-3.7-4 0-.9.3-1.6.8-2.2 0-.2-.3-1 .1-2 0 0 .7-.3 2.2.7a7.4 7.4 0 0 1 4 0c1.5-1 2.2-.8 2.2-.8.5 1.1.2 2 .1 2.1.5.6.8 1.3.8 2.2 0 3-1.9 3.7-3.6 4 .3.2.5.7.5 1.4v2.2c0 .2.1.5.5.4A8 8 0 0 0 16 8a8 8 0 0 0-8-8z"
+                  />
+                </svg>
+                <span>See repo on GitHub</span>
+              </a>
+            </p>
+          )
+        }
+      </div>
+    </header>
+
+    <section class="space-y-4">
+      <h2 class="flex gap-2 items-center">
+        <span class="font-bold text-2xl">
+          Contributors with this achievement
+        </span>
+        <span class="px-3 py-1 bg-neutral-800 rounded-full">
+          {contributors.length}
+        </span>
+      </h2>
+
+      <ul class="flex flex-wrap gap-2 sm:gap-4 sm:text-lg -mx-2">
+        {
+          contributors.map((contributor) => (
+            <li class="flex items-center p-2 gap-2 relative rounded text-neutral-300 hover:text-neutral-50 hover:bg-neutral-800">
+              <img
+                width="28"
+                height="28"
+                src={contributor.avatar_url}
+                alt=""
+                class="w-7 h-7 rounded-full object-cover bg-neutral-700"
+                loading="lazy"
+                decoding="async"
+              />
+              <a
+                href={`/v1/contributor/${contributor.username}/`}
+                class="after:absolute after:inset-0"
+              >
+                {contributor.username}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+
+    <footer class="my-24">
+      <CTA href="/v1/achievements">← Browse achievements</CTA>
+    </footer>
+  </div>
+</Layout>

--- a/src/pages/v1/achievements/[groupID]/[class].astro
+++ b/src/pages/v1/achievements/[groupID]/[class].astro
@@ -3,6 +3,7 @@ import CTA from '../../../../components/CTA.astro';
 import Layout from '../../../../layouts/Layout.astro';
 import { globalAchievements } from '../../../../util/getGlobalStats';
 import {
+  achievementClassEmoji,
   achievementClassGradientFrom,
   achievementClassSlug,
 } from '../../../../util/achievementClasses';
@@ -23,7 +24,10 @@ type Props = typeof globalAchievements[number];
 const { title, details, contributors, class: cls, repo } = Astro.props;
 ---
 
-<Layout title={`${title} — Astro Achievements`} description={details}>
+<Layout
+  title={`${title} ${achievementClassEmoji(cls)} — Astro Achievements`}
+  description={`${details}. See Astro contributors with this achievement.`}
+>
   <div class="space-y-16">
     <header class="space-y-2">
       <h1 class="text-4xl font-extrabold">

--- a/src/pages/v1/achievements/index.astro
+++ b/src/pages/v1/achievements/index.astro
@@ -1,0 +1,71 @@
+---
+import CTA from '../../../components/CTA.astro';
+import Layout from '../../../layouts/Layout.astro';
+import { globalAchievements } from '../../../util/getGlobalStats';
+import {
+  achievementClassGradientFrom,
+  achievementClassLabel,
+  achievementClassSlug,
+} from '../../../util/achievementClasses';
+
+/** Achievements sorted alphabetically by their title. */
+const achievements = globalAchievements.sort((a, b) =>
+  a.title > b.title ? 1 : -1
+);
+---
+
+<Layout
+  title="All Achievements — Astro Achievements"
+  description="List of all achievements Astro contributors have collected."
+>
+  <div class="space-y-16">
+    <h1 class="text-4xl font-extrabold">All Achievements</h1>
+
+    {
+      [2, 1, 0].map((cls) => (
+        <div class="space-y-4 sm:space-y-6">
+          <h3 class="font-black text-3xl">
+            <span
+              class:list={[
+                'bg-gradient-to-br to-white inline-block w-6 h-6 mr-0.5 rounded-full translate-y-px',
+                achievementClassGradientFrom(cls),
+              ]}
+            />
+            <span
+              class:list={[
+                'bg-gradient-to-br to-white bg-clip-text text-transparent',
+                achievementClassGradientFrom(cls),
+              ]}
+            >
+              {achievementClassLabel(cls)}
+            </span>
+          </h3>
+
+          <ul class="flex flex-wrap gap-2 sm:gap-4 -m-2">
+            {achievements
+              .filter((a) => a.class === cls)
+              .map((achievement) => (
+                <li class="flex gap-1.5 items-center hover:bg-neutral-800 p-2 rounded sm:text-lg relative">
+                  <a
+                    class="text-neutral-300 hover:text-neutral-50 after:inset-0 after:absolute"
+                    href={`/v1/achievements/${
+                      achievement.groupID
+                    }/${achievementClassSlug(achievement.class)}/`}
+                  >
+                    {achievement.title}
+                  </a>
+                  <span class="bg-neutral-50/10 text-xs text-center py-1 px-2 min-w-[2em] rounded-full">
+                    {achievement.numAchieved}
+                  </span>
+                </li>
+              ))}
+          </ul>
+        </div>
+      ))
+    }
+
+    <footer class="my-24">
+      <CTA href="/contributors">Find a contributor →</CTA>
+    </footer>
+  </div>
+</Layout>

--- a/src/pages/v1/contributor/[username].astro
+++ b/src/pages/v1/contributor/[username].astro
@@ -5,6 +5,7 @@ import { contributors } from "../../../util/getContributors";
 import Layout from '../../../layouts/Layout.astro';
 import CTA from "../../../components/CTA.astro";
 import Stat from "../../../components/achievements/Stat.astro";
+import { achievementClassBg, achievementClassGradientFrom, achievementClassText } from '../../../util/style'
 
 export function getStaticPaths() {
   return contributors.map((contributor) => ({
@@ -73,9 +74,7 @@ const htmlSnippet = `<a href="${Astro.url.href}">\n  <img src="${Astro.site}v1/c
         {achievements.map((group) => {
           const { title, details, numAchieved } = group.achievements[0];
           const percentage = numAchieved / contributors.length * 100;
-          const classBg = ['bg-bronze', 'bg-silver', 'bg-gold'];
-          const classText = ['text-bronze', 'text-silver', 'text-gold'];
-          const gradientFrom = ['from-bronze', 'from-silver', 'from-gold'][group.class];
+          const gradientFrom = achievementClassGradientFrom(group.class);
           return (
             <li class="space-y-5">
               <div class="space-y-1">
@@ -99,8 +98,8 @@ const htmlSnippet = `<a href="${Astro.url.href}">\n  <img src="${Astro.site}v1/c
                     {group.achievements.map((previous, i) => i > 0 && (
                       <li>
                         <div class="flex items-baseline space-x-2">
-                          <span class:list={["inline-block w-2 h-2 rounded-full", classBg[previous.class]]} />
-                          <h5 class:list={["font-bold", classText[previous.class]]}>
+                          <span class:list={["inline-block w-2 h-2 rounded-full", achievementClassBg(previous.class)]} />
+                          <h5 class:list={["font-bold", achievementClassText(previous.class)]}>
                             {previous.title}
                           </h5>
                           <p class="text-xs">{previous.details}</p>

--- a/src/pages/v1/contributor/[username].astro
+++ b/src/pages/v1/contributor/[username].astro
@@ -79,10 +79,12 @@ const htmlSnippet = `<a href="${Astro.url.href}">\n  <img src="${Astro.site}v1/c
             <li class="space-y-5">
               <div class="space-y-1">
                 <h3 class="font-black text-3xl shrink-0">
-                  <span class:list={["bg-gradient-to-br to-white inline-block w-6 h-6 mr-0.5 rounded-full translate-y-px", gradientFrom]} />
-                  <span class:list={["bg-gradient-to-br to-white bg-clip-text text-transparent", gradientFrom]}>
-                    {title}
-                  </span>
+                  <a href={`/v1/achievements/${group.groupID}/${achievementClassSlug(group.class)}/`}>
+                    <span class:list={["bg-gradient-to-br to-white inline-block w-6 h-6 mr-0.5 rounded-full translate-y-px", gradientFrom]} />
+                    <span class:list={["bg-gradient-to-br to-white bg-clip-text text-transparent", gradientFrom]}>
+                      {title}
+                    </span>
+                  </a>
                 </h3>
                 <p class="text-xl font-light text-white">{details}</p>
                 <p class="text-xs leading-6">
@@ -100,7 +102,7 @@ const htmlSnippet = `<a href="${Astro.url.href}">\n  <img src="${Astro.site}v1/c
                         <div class="flex items-baseline space-x-2">
                           <span class:list={["inline-block w-2 h-2 rounded-full", achievementClassBg(previous.class)]} />
                           <h5 class:list={["font-bold", achievementClassText(previous.class)]}>
-                            {previous.title}
+                            <a href={`/v1/achievements/${group.groupID}/${achievementClassSlug(previous.class)}/`}>{previous.title}</a>
                           </h5>
                           <p class="text-xs">{previous.details}</p>
                         </div>

--- a/src/pages/v1/contributor/[username].astro
+++ b/src/pages/v1/contributor/[username].astro
@@ -5,7 +5,7 @@ import { contributors } from "../../../util/getContributors";
 import Layout from '../../../layouts/Layout.astro';
 import CTA from "../../../components/CTA.astro";
 import Stat from "../../../components/achievements/Stat.astro";
-import { achievementClassBg, achievementClassGradientFrom, achievementClassText } from '../../../util/style'
+import { achievementClassBg, achievementClassGradientFrom, achievementClassSlug, achievementClassText } from '../../../util/achievementClasses'
 
 export function getStaticPaths() {
   return contributors.map((contributor) => ({

--- a/src/util/achievementClasses.ts
+++ b/src/util/achievementClasses.ts
@@ -14,3 +14,6 @@ export const achievementClassSlug = (cls: AchievementClass) =>
 
 export const achievementClassLabel = (cls: AchievementClass) =>
   (['Bronze', 'Silver', 'Gold'] as const)[cls];
+
+export const achievementClassEmoji = (cls: AchievementClass) =>
+  (['🥉', '🥈', '🥇'] as const)[cls];

--- a/src/util/achievementClasses.ts
+++ b/src/util/achievementClasses.ts
@@ -8,3 +8,9 @@ export const achievementClassText = (cls: AchievementClass) =>
 
 export const achievementClassGradientFrom = (cls: AchievementClass) =>
   (['from-bronze', 'from-silver', 'from-gold'] as const)[cls];
+
+export const achievementClassSlug = (cls: AchievementClass) =>
+  (['bronze', 'silver', 'gold'] as const)[cls];
+
+export const achievementClassLabel = (cls: AchievementClass) =>
+  (['Bronze', 'Silver', 'Gold'] as const)[cls];

--- a/src/util/getGlobalStats.ts
+++ b/src/util/getGlobalStats.ts
@@ -1,0 +1,30 @@
+import type { Achievement, AchievementClass } from './achievementsHelpers';
+import { contributors } from './getContributors';
+
+interface Stat extends Achievement {
+  groupID: string;
+  repo?: string;
+  contributors: typeof contributors;
+}
+
+export const globalAchievements: Stat[] = Object.values(
+  contributors.reduce((stats, contributor) => {
+    contributor.achievements.forEach((group) => {
+      if (!stats[group.groupID]) {
+        stats[group.groupID] = {};
+      }
+      for (const achievement of group.achievements) {
+        if (!stats[group.groupID][achievement.class]) {
+          stats[group.groupID][achievement.class] = {
+            ...achievement,
+            groupID: group.groupID,
+            repo: group.repo,
+            contributors: [],
+          };
+        }
+        stats[group.groupID][achievement.class].contributors.push(contributor);
+      }
+    });
+    return stats;
+  }, {} as Record<string, Partial<Record<AchievementClass, Stat>>>)
+).flatMap((group) => Object.values(group));

--- a/src/util/resizedGitHubAvatarURL.ts
+++ b/src/util/resizedGitHubAvatarURL.ts
@@ -1,0 +1,5 @@
+export const resizedGitHubAvatarURL = (avatarURL: string, size: number) => {
+  const url = new URL(avatarURL);
+  url.searchParams.set('s', String(size));
+  return url.href;
+};

--- a/src/util/style.ts
+++ b/src/util/style.ts
@@ -1,0 +1,10 @@
+import type { AchievementClass } from './achievementsHelpers';
+
+export const achievementClassBg = (cls: AchievementClass) =>
+  (['bg-bronze', 'bg-silver', 'bg-gold'] as const)[cls];
+
+export const achievementClassText = (cls: AchievementClass) =>
+  (['text-bronze', 'text-silver', 'text-gold'] as const)[cls];
+
+export const achievementClassGradientFrom = (cls: AchievementClass) =>
+  (['from-bronze', 'from-silver', 'from-gold'] as const)[cls];


### PR DESCRIPTION
Adds a dedicated page for each achievement and an index listing them all:

<img width="841" alt="image" src="https://user-images.githubusercontent.com/357379/216792026-ee74af9f-eedb-4589-9c33-55fad418e13e.png">
