### PR TITLE
Include reviews of old docs translation location in i18n category

### DIFF
--- a/scripts/collect-stats.ts
+++ b/scripts/collect-stats.ts
@@ -220,6 +220,8 @@ const collector = new StatsCollector({
         "src/content/docs/!(en)/**/*",
         // Astro Docs labels translations 
         "src/i18n/!(en)/**/*",
+        // Astro Docs translations before migrating to Content Collections
+        "src/pages/(ar|de|es|fr|ja|pl|pt-br|ru|zh-cn|zh-tw)/**/*",
       ],
       starlight: [
         // Starlight Docs content translations


### PR DESCRIPTION
We added an `i18n` review category for comments on files in `src/content/` in docs, but also had some major contributors reviewing content when content lived in `src/pages/` (pre content collection migration).

This PR adds those old locations to the globs for i18n so that our reviewers get full credit. I hard coded the relevant languages given that they’re not going to change — based on the final state of the repo before migrating to content collections: https://github.com/withastro/docs/tree/40446666daf7a053cb78355905b810f9cf845fb4/src/pages