### PR TITLE
Fix glob pattern for legacy docs content

### DIFF
--- a/scripts/collect-stats.ts
+++ b/scripts/collect-stats.ts
@@ -221,7 +221,7 @@ const collector = new StatsCollector({
         // Astro Docs labels translations 
         "src/i18n/!(en)/**/*",
         // Astro Docs translations before migrating to Content Collections
-        "src/pages/(ar|de|es|fr|ja|pl|pt-br|ru|zh-cn|zh-tw)/**/*",
+        "src/pages/+(ar|de|es|fr|ja|pl|pt-br|ru|zh-cn|zh-tw)/**/*",
       ],
       starlight: [
         // Starlight Docs content translations


### PR DESCRIPTION
[`minimatch`](https://github.com/isaacs/minimatch#readme) uses extglob style `+()` for groups, but #17 only used `()` to group language directory names. This PR fixes that.