### PR TITLE
Code on bwa of URL snippets

### DIFF
--- a/src/pages/bwa.astro
+++ b/src/pages/bwa.astro
@@ -7,10 +7,6 @@ const description = "“Built with Astro” SVG badges to add to your sites and 
 
 const mdSnippet = `[![Built with Astro](${Astro.site}v1/built-with-astro/tiny.svg)](https://astro.build)`;
 const htmlSnippet = `<a href="https://astro.build">\n  <img src="${Astro.site}v1/built-with-astro/tiny.svg" alt="Built with Astro" width="109" height="20">\n</a>`;
-const tinyUrlSnippet = `${Astro.site}v1/built-with-astro/tiny.svg`;
-const smallUrlSnippet = `${Astro.site}v1/built-with-astro/small.svg`;
-const mediumUrlSnippet = `${Astro.site}v1/built-with-astro/medium.svg`;
-const largeUrlSnippet = `${Astro.site}v1/built-with-astro/large.svg`;
 ---
 
 <Layout {title} {description}>
@@ -42,20 +38,20 @@ const largeUrlSnippet = `${Astro.site}v1/built-with-astro/large.svg`;
 
     <h2>Sizes</h2>
 
-    <h3>Tiny</h3>
-    <Code code={tinyUrlSnippet} lang="html" />
+   <h3>Tiny</h3>
+    <p><code>{Astro.site}v1/built-with-astro/tiny.svg</code></p>
     <p><img src="/v1/built-with-astro/tiny.svg" alt="Built with Astro" /></p>
 
     <h3>Small</h3>
-    <Code code={smallUrlSnippet} lang="html" />
+    <p><code>{Astro.site}v1/built-with-astro/small.svg</code></p>
     <p><img src="/v1/built-with-astro/small.svg" alt="Built with Astro" /></p>
 
     <h3>Medium</h3>
-    <Code code={mediumUrlSnippet} lang="html" />
+    <p><code>{Astro.site}v1/built-with-astro/medium.svg</code></p>
     <p><img src="/v1/built-with-astro/medium.svg" alt="Built with Astro" /></p>
 
     <h3>Large</h3>
-    <Code code={largeUrlSnippet} lang="html" />
+    <p><code>{Astro.site}v1/built-with-astro/large.svg</code></p>
     <p><img src="/v1/built-with-astro/large.svg" alt="Built with Astro" /></p>
   </div>
 </Layout>

--- a/src/pages/bwa.astro
+++ b/src/pages/bwa.astro
@@ -7,6 +7,10 @@ const description = "“Built with Astro” SVG badges to add to your sites and 
 
 const mdSnippet = `[![Built with Astro](${Astro.site}v1/built-with-astro/tiny.svg)](https://astro.build)`;
 const htmlSnippet = `<a href="https://astro.build">\n  <img src="${Astro.site}v1/built-with-astro/tiny.svg" alt="Built with Astro" width="109" height="20">\n</a>`;
+const tinyUrlSnippet = `{Astro.site}v1/built-with-astro/tiny.svg`;
+const smallUrlSnippet = `{Astro.site}v1/built-with-astro/small.svg`;
+const mediumUrlSnippet = `{Astro.site}v1/built-with-astro/medium.svg`;
+const largeUrlSnippet = `{Astro.site}v1/built-with-astro/large.svg`;
 ---
 
 <Layout {title} {description}>
@@ -39,19 +43,19 @@ const htmlSnippet = `<a href="https://astro.build">\n  <img src="${Astro.site}v1
     <h2>Sizes</h2>
 
     <h3>Tiny</h3>
-    <p><code>{Astro.site}v1/built-with-astro/tiny.svg</code></p>
+    <Code code={tinyUrlSnippet} lang="html" />
     <p><img src="/v1/built-with-astro/tiny.svg" alt="Built with Astro" /></p>
 
     <h3>Small</h3>
-    <p><code>{Astro.site}v1/built-with-astro/small.svg</code></p>
+    <Code code={smallUrlSnippet} lang="html" />
     <p><img src="/v1/built-with-astro/small.svg" alt="Built with Astro" /></p>
 
     <h3>Medium</h3>
-    <p><code>{Astro.site}v1/built-with-astro/medium.svg</code></p>
+    <Code code={mediumUrlSnippet} lang="html" />
     <p><img src="/v1/built-with-astro/medium.svg" alt="Built with Astro" /></p>
 
     <h3>Large</h3>
-    <p><code>{Astro.site}v1/built-with-astro/large.svg</code></p>
+    <Code code={largeUrlSnippet} lang="html" />
     <p><img src="/v1/built-with-astro/large.svg" alt="Built with Astro" /></p>
   </div>
 </Layout>

--- a/src/pages/bwa.astro
+++ b/src/pages/bwa.astro
@@ -7,10 +7,10 @@ const description = "“Built with Astro” SVG badges to add to your sites and 
 
 const mdSnippet = `[![Built with Astro](${Astro.site}v1/built-with-astro/tiny.svg)](https://astro.build)`;
 const htmlSnippet = `<a href="https://astro.build">\n  <img src="${Astro.site}v1/built-with-astro/tiny.svg" alt="Built with Astro" width="109" height="20">\n</a>`;
-const tinyUrlSnippet = `{Astro.site}v1/built-with-astro/tiny.svg`;
-const smallUrlSnippet = `{Astro.site}v1/built-with-astro/small.svg`;
-const mediumUrlSnippet = `{Astro.site}v1/built-with-astro/medium.svg`;
-const largeUrlSnippet = `{Astro.site}v1/built-with-astro/large.svg`;
+const tinyUrlSnippet = `${Astro.site}v1/built-with-astro/tiny.svg`;
+const smallUrlSnippet = `${Astro.site}v1/built-with-astro/small.svg`;
+const mediumUrlSnippet = `${Astro.site}v1/built-with-astro/medium.svg`;
+const largeUrlSnippet = `${Astro.site}v1/built-with-astro/large.svg`;
 ---
 
 <Layout {title} {description}>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -14,7 +14,15 @@ module.exports = {
         silver: 'hsl(210, 6%, 72%)',
         gold: 'hsl(48, 100%, 50%)',
       },
-    },
+      typography: {
+        "code::before": {
+          content: '""',
+        },
+        "code::after": {
+          content: '""',
+        },
+      }
+    }
   },
   plugins: [
 		require('@tailwindcss/typography'),

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -15,11 +15,13 @@ module.exports = {
         gold: 'hsl(48, 100%, 50%)',
       },
       typography: {
-        "code::before": {
-          content: '""',
-        },
-        "code::after": {
-          content: '""',
+        DEFAULT: {
+          "code::before": {
+            content: '""',
+          },
+          "code::after": {
+            content: '""',
+          },
         },
       }
     }


### PR DESCRIPTION
Editing code parts of URL snippets for tiny/small/medium/large badges on BWA page. Because it's more simple to copy that and better design.

Actual : 

![Actual page of BWA on Astro Badges](https://github.com/delucis/astro-badge/assets/14293805/9e4f0361-d08d-4c7c-8ced-38c84ebc8871)

```html
<Code code={tinyUrlSnippet} lang="html" />
```