### PR TITLE
Add new Astro Badges for Hacktoberfest

### DIFF
--- a/src/achievements.config.ts
+++ b/src/achievements.config.ts
@@ -155,6 +155,22 @@ export default AchievementSpec({
       { count: 30, title: 'Superstar', details: '30 starlight PRs' },
     ],
   },
+  'hacktoberfest-merges': {
+    getCount: ({ merged_pulls_by_label }) => {
+      if (!merged_pulls_by_label) return 0;
+      let sum = 0;
+      for (const repo of Object.keys(merged_pulls_by_label)) {
+        if (merged_pulls_by_label[repo]["hacktoberfest-accepted"])
+          sum += merged_pulls_by_label[repo]["hacktoberfest-accepted"];
+      }
+      return sum;
+    },
+    achievements: [
+      { count: 1, title: 'Commit Trickster', details: '1 Hacktoberfest contribution' },
+      { count: 2, title: 'Brewer of PRs', details: '2 Hacktoberfest contributions' },
+      { count: 4, title: 'Hack-o-Lantern', details: '4 Hacktoberfest contributions' },
+    ],
+  },
   'total-issues': {
     stat: 'issues',
     achievements: [

--- a/src/achievements.config.ts
+++ b/src/achievements.config.ts
@@ -166,9 +166,9 @@ export default AchievementSpec({
       return sum;
     },
     achievements: [
-      { count: 1, title: 'Commit Trickster', details: '1 Hacktoberfest contribution' },
-      { count: 2, title: 'Brewer of PRs', details: '2 Hacktoberfest contributions' },
-      { count: 4, title: 'Hack-o-Lantern', details: '4 Hacktoberfest contributions' },
+      { count: 1, title: 'Hacker', details: '1 Hacktoberfest contribution' },
+      { count: 5, title: 'Commit or Treat', details: '5 Hacktoberfest contributions' },
+      { count: 15, title: 'Hack-o-Lantern', details: '15 Hacktoberfest contributions' },
     ],
   },
   'total-issues': {


### PR DESCRIPTION
This PR adds new badges for Hacktoberfest contributions. Note that all achievements need the three ranks (or else TypeScript complains). We could change the achievement levels' count to 4/8/12 to consider full participation in 3 editions of Hacktoberfest, or as I did, 1/2/4 for only one. For context, 4 is the number of PRs needed to get the digital reward.

I tried names that were related to events happening in October (not only Hacktoberfest), like Halloween and, well, Oktoberfest.

A few other achievement names I thought of:
- Commit or Treat
- Bounty Hacker
- Hacker
- OctoHacker

Example of the final badges (couldn't find a peep with only one contribution):
![breadadams's Astro contributions badge](https://github.com/delucis/astro-badge/assets/61414485/a66e608e-8de6-455d-af87-3916eddc5e6a)
![agustinmulet's Astro contributions badge](https://github.com/delucis/astro-badge/assets/61414485/f01cd4e9-d113-4e39-9bd1-c9355bd71e30)
