### PR TITLE
Add built-in support for label and review achievements

### DIFF
--- a/src/achievements.config.ts
+++ b/src/achievements.config.ts
@@ -14,15 +14,8 @@ export default AchievementSpec({
     ],
   },
   'i18n-reviews': {
-    getCount: ({ reviews_by_category }) => {
-      if (!reviews_by_category) return 0;
-      let sum = 0;
-      for (const repo of Object.keys(reviews_by_category)) {
-        if (reviews_by_category[repo]['i18n']) 
-          sum += reviews_by_category[repo]['i18n'];
-      }
-      return sum;
-    },
+    stat: 'reviews_by_category',
+    category: 'i18n',
     achievements: [
       { count: 1, title: 'Proofreader', details: 'Reviewed an i18n PR' },
       { count: 15, title: 'Polyglot', details: 'Reviewed 15 i18n PRs' },
@@ -30,7 +23,7 @@ export default AchievementSpec({
     ]
   },
   'i18n-merges': {
-    stat: 'merges_by_label',
+    stat: 'merged_pulls_by_label',
     label: 'i18n',
     achievements: [
       { count: 1, title: 'Decoder', details: 'First i18n PR' },
@@ -149,7 +142,7 @@ export default AchievementSpec({
     ],
   },
   'hacktoberfest-merges': {
-    stat: 'merges_by_label',
+    stat: 'merged_pulls_by_label',
     label: 'hacktoberfest-accepted',
     achievements: [
       { count: 1, title: 'Hacker', details: '1 Hacktoberfest contribution' },

--- a/src/achievements.config.ts
+++ b/src/achievements.config.ts
@@ -30,15 +30,8 @@ export default AchievementSpec({
     ]
   },
   'i18n-merges': {
-    getCount: ({ merged_pulls_by_label }) => {
-      if (!merged_pulls_by_label) return 0;
-      let sum = 0;
-      for (const repo of Object.keys(merged_pulls_by_label)) {
-        if (merged_pulls_by_label[repo]['i18n']) 
-          sum += merged_pulls_by_label[repo]['i18n'];
-      }
-      return sum;
-    },
+    stat: 'merges_by_label',
+    label: 'i18n',
     achievements: [
       { count: 1, title: 'Decoder', details: 'First i18n PR' },
       { count: 15, title: 'Babel Fish', details: '15 i18n PRs' },
@@ -156,15 +149,8 @@ export default AchievementSpec({
     ],
   },
   'hacktoberfest-merges': {
-    getCount: ({ merged_pulls_by_label }) => {
-      if (!merged_pulls_by_label) return 0;
-      let sum = 0;
-      for (const repo of Object.keys(merged_pulls_by_label)) {
-        if (merged_pulls_by_label[repo]["hacktoberfest-accepted"])
-          sum += merged_pulls_by_label[repo]["hacktoberfest-accepted"];
-      }
-      return sum;
-    },
+    stat: 'merges_by_label',
+    label: 'hacktoberfest-accepted',
     achievements: [
       { count: 1, title: 'Hacker', details: '1 Hacktoberfest contribution' },
       { count: 5, title: 'Commit or Treat', details: '5 Hacktoberfest contributions' },

--- a/src/util/achievementsHelpers.ts
+++ b/src/util/achievementsHelpers.ts
@@ -41,12 +41,17 @@ interface BuiltinAchievementGroup extends AchievementGroupBase {
   stat: 'merges' | 'issues' | 'reviews';
 }
 
+interface LabelAchievementGroup extends AchievementGroupBase {
+  stat: 'merges_by_label';
+  label: string;
+}
+
 interface CustomAchievementGroup extends AchievementGroupBase {
   /** A custom function to calculate the stat count for this achievement. */
   getCount: (contributor: Contributor) => number;
 }
 
-type AchievementGroup = BuiltinAchievementGroup | CustomAchievementGroup;
+type AchievementGroup = BuiltinAchievementGroup | LabelAchievementGroup | CustomAchievementGroup;
 
 export function AchievementSpec(spec: Record<string, AchievementGroup>) {
   return Object.fromEntries(

--- a/src/util/achievementsHelpers.ts
+++ b/src/util/achievementsHelpers.ts
@@ -29,11 +29,7 @@ interface AchievementGroupBase {
    */
   repo?: string;
   /** Tuple of achievements in ascending order: `[bronze, silver, gold]`. */
-  achievements: [
-    bronze: AchievementDef,
-    silver: AchievementDef,
-    gold: AchievementDef
-  ];
+  achievements: [bronze: AchievementDef, silver: AchievementDef, gold: AchievementDef];
 }
 
 interface BuiltinAchievementGroup extends AchievementGroupBase {
@@ -42,8 +38,13 @@ interface BuiltinAchievementGroup extends AchievementGroupBase {
 }
 
 interface LabelAchievementGroup extends AchievementGroupBase {
-  stat: 'merges_by_label';
+  stat: 'merged_pulls_by_label';
   label: string;
+}
+
+interface CategoryAchievementGroup extends AchievementGroupBase {
+  stat: 'reviews_by_category';
+  category: string;
 }
 
 interface CustomAchievementGroup extends AchievementGroupBase {
@@ -51,7 +52,11 @@ interface CustomAchievementGroup extends AchievementGroupBase {
   getCount: (contributor: Contributor) => number;
 }
 
-type AchievementGroup = BuiltinAchievementGroup | LabelAchievementGroup | CustomAchievementGroup;
+type AchievementGroup =
+  | BuiltinAchievementGroup
+  | LabelAchievementGroup
+  | CustomAchievementGroup
+  | CategoryAchievementGroup;
 
 export function AchievementSpec(spec: Record<string, AchievementGroup>) {
   return Object.fromEntries(

--- a/src/util/getAchievements.ts
+++ b/src/util/getAchievements.ts
@@ -17,11 +17,11 @@ function getAchievementsFromSpec(contributor: Contributor) {
     let count: number;
     if ('getCount' in group) {
       count = group.getCount(contributor);
-    } else if (group.stat === 'merges_by_label') {
-      const merges = contributor.merged_pulls_by_label;
+    } else if (group.stat === 'merged_pulls_by_label' || group.stat === 'reviews_by_category') {
+      const key = group.stat === 'merged_pulls_by_label' ? group.label : group.category;
       count = repo
-        ? merges[repo][group.label] || 0
-        : Object.values(merges).reduce((sum, repo) => sum + (repo[group.label] || 0), 0);
+        ? contributor[group.stat][repo][key] || 0
+        : Object.values(contributor[group.stat]).reduce((sum, repo) => sum + (repo[key] || 0), 0);
     } else {
       const stat = group.stat === 'merges' ? 'merged_pulls' : group.stat;
       count = repo ? contributor[stat][repo] : objSum(contributor[stat]);

--- a/src/util/getAchievements.ts
+++ b/src/util/getAchievements.ts
@@ -17,6 +17,11 @@ function getAchievementsFromSpec(contributor: Contributor) {
     let count: number;
     if ('getCount' in group) {
       count = group.getCount(contributor);
+    } else if (group.stat === 'merges_by_label') {
+      const merges = contributor.merged_pulls_by_label;
+      count = repo
+        ? merges[repo][group.label] || 0
+        : Object.values(merges).reduce((sum, repo) => sum + (repo[group.label] || 0), 0);
     } else {
       const stat = group.stat === 'merges' ? 'merged_pulls' : group.stat;
       count = repo ? contributor[stat][repo] : objSum(contributor[stat]);


### PR DESCRIPTION
Adds `reviews_by_category` and `merged_pulls_by_label` achievement types so that badges depending on this data don’t need to use the `getCount()` form to calculate totals.