### PR TITLE
Add tooltip to progress meters

### DIFF
--- a/src/components/achievements/Stat.astro
+++ b/src/components/achievements/Stat.astro
@@ -40,16 +40,19 @@ const query = `${subPath}?q=${isType}+${userFilter}`
             >
               {repo}
             </a>
-            <span class="pl-2">
+            <span
+              class="pl-2"
+            >
               <span
                 class="block w-[var(--bar-w)] min-w-[2px] bg-blue-purple-gradient h-2 rounded-full group relative"
                 style={`--bar-w: ${percentage}%;`}
               >
-                <span class="not-sr-only invisible absolute z-50 -mt-8 rounded bg-gray-100 p-1 text-neutral-700 shadow-lg group-hover:visible">
+                <span class="sr-only">{repoCount} {type}</span>
+                <span
+                  aria-hidden="true"
+                  class="invisible absolute z-50 -mt-8 rounded bg-gray-100 p-1 text-neutral-700 shadow-lg group-hover:visible"
+                >
                   {repoCount.toString()}
-                </span>
-                <span class="sr-only">
-                  {repoCount} {type}
                 </span>
               </span>
             </span>

--- a/src/components/achievements/Stat.astro
+++ b/src/components/achievements/Stat.astro
@@ -40,15 +40,17 @@ const query = `${subPath}?q=${isType}+${userFilter}`
             >
               {repo}
             </a>
-            <span
-              class="pl-2"
-              title={repoCount.toString()}
-            >
+            <span class="pl-2">
               <span
-                class="block w-[var(--bar-w)] min-w-[2px] bg-blue-purple-gradient h-2 rounded-full"
+                class="block w-[var(--bar-w)] min-w-[2px] bg-blue-purple-gradient h-2 rounded-full group relative"
                 style={`--bar-w: ${percentage}%;`}
               >
-                <span class="sr-only">{repoCount} {type}</span>
+                <span class="not-sr-only invisible absolute z-50 -mt-8 rounded bg-gray-100 p-1 text-neutral-700 shadow-lg group-hover:visible">
+                  {repoCount.toString()}
+                </span>
+                <span class="sr-only">
+                  {repoCount} {type}
+                </span>
               </span>
             </span>
           </li>

--- a/src/components/achievements/Stat.astro
+++ b/src/components/achievements/Stat.astro
@@ -42,6 +42,7 @@ const query = `${subPath}?q=${isType}+${userFilter}`
             </a>
             <span
               class="pl-2"
+              title={repoCount.toString()}
             >
               <span
                 class="block w-[var(--bar-w)] min-w-[2px] bg-blue-purple-gradient h-2 rounded-full"

--- a/src/components/achievements/Stat.astro
+++ b/src/components/achievements/Stat.astro
@@ -50,7 +50,7 @@ const query = `${subPath}?q=${isType}+${userFilter}`
                 <span class="sr-only">{repoCount} {type}</span>
                 <span
                   aria-hidden="true"
-                  class="invisible absolute z-50 -mt-8 rounded bg-gray-100 p-1 text-neutral-700 shadow-lg group-hover:visible"
+                  class="invisible absolute z-50 -mt-8 rounded bg-gray-100 p-1 text-neutral-700 opacity-0 transition-opacity duration-300 ease-in-out group-hover:visible group-hover:opacity-100"
                 >
                   {repoCount.toString()}
                 </span>


### PR DESCRIPTION
- closes #46 
- a plain tooltip is added to the progress meters in the Stat section

> Info unrelated to the PR: During local setup, I receive this `Could not load the "sharp" module using the win32-x64 runtime` error.
```js
Astro                    v4.0.0
Node                     v20.10.0
System                   Windows (x64)
Package Manager          pnpm
Output                   static
Adapter                  none
Integrations             @astrojs/tailwind
```
commit/PR itself are done via Gitpod in the meantime🙏 